### PR TITLE
✨ Added support for presence channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/core": "^7.7.7",
     "@babel/preset-env": "^7.7.7",
     "@types/jest": "^24.0.24",
+    "@types/pusher-js": "^4.2.2",
     "babel-jest": "^24.9.0",
     "husky": "^0.14.3",
     "jest": "^24.9.0",

--- a/src/__tests__/pusher-channel-mock.spec.ts
+++ b/src/__tests__/pusher-channel-mock.spec.ts
@@ -1,78 +1,78 @@
-import { PusherChannelMock } from "../index";
+import { PusherChannelMock } from '../index';
 
-describe("PusherChannelMock", () => {
+describe('PusherChannelMock', () => {
   let channelMock: PusherChannelMock;
 
   beforeEach(() => {
     channelMock = new PusherChannelMock();
   });
 
-  it("initializes callbacks object", () => {
+  it('initializes callbacks object', () => {
     expect(channelMock.callbacks).toEqual({});
   });
 
-  describe("#bind", () => {
-    it("adds name: callback to callbacks object", () => {
+  describe('#bind', () => {
+    it('adds name: callback to callbacks object', () => {
       const callback = () => {};
-      channelMock.bind("my-channel", callback);
+      channelMock.bind('my-channel', callback);
 
-      expect(channelMock.callbacks).toMatchObject({ "my-channel": [callback] });
-      expect(channelMock.callbacks["my-channel"]).toEqual([callback]);
+      expect(channelMock.callbacks).toMatchObject({ 'my-channel': [callback] });
+      expect(channelMock.callbacks['my-channel']).toEqual([callback]);
     });
   });
 
-  describe("#unbind", () => {
-    describe("with callbacks defined for the event", () => {
-      it("removes name: callback from callbacks object", () => {
+  describe('#unbind', () => {
+    describe('with callbacks defined for the event', () => {
+      it('removes name: callback from callbacks object', () => {
         const callback = () => {};
-        channelMock.bind("my-channel", callback);
-        channelMock.unbind("my-channel", callback);
+        channelMock.bind('my-channel', callback);
+        channelMock.unbind('my-channel', callback);
 
         expect(channelMock.callbacks).toEqual({
-          "my-channel": []
+          'my-channel': [],
         });
       });
     });
 
-    describe("without callbacks defined for the event", () => {
-      it("removes name: callback from callbacks object", () => {
+    describe('without callbacks defined for the event', () => {
+      it('removes name: callback from callbacks object', () => {
         const callback = () => {};
-        channelMock.unbind("my-channel", callback);
+        channelMock.unbind('my-channel', callback);
 
         expect(channelMock.callbacks).toEqual({
-          "my-channel": []
+          'my-channel': [],
         });
       });
     });
   });
 
-  describe("#emit", () => {
-    describe("callback is defined for given channel name", () => {
+  describe('#emit', () => {
+    describe('callback is defined for given channel name', () => {
       let callback: () => void;
 
       beforeEach(() => {
         callback = jest.fn();
-        channelMock.bind("my-channel", callback);
+        channelMock.bind('my-channel', callback);
       });
 
-      it("calls callback", () => {
-        channelMock.emit("my-channel");
+      it('calls callback', () => {
+        channelMock.emit('my-channel');
 
         expect(callback).toHaveBeenCalledTimes(1);
       });
 
-      it("calls callback with data", () => {
-        const data = "you used to call me on my cellphone";
-        channelMock.emit("my-channel", data);
+      it('calls callback with data', () => {
+        const data = 'you used to call me on my cellphone';
+        channelMock.emit('my-channel', data);
 
-        expect(callback).toBeCalledWith("you used to call me on my cellphone");
+        expect(callback).toBeCalledWith('you used to call me on my cellphone');
       });
     });
 
-    describe("callback is not defined for given channel name", () => {
-      it("returns null", () => {
+    describe('callback is not defined for given channel name', () => {
+      it('returns null', () => {
         const callback = jest.fn();
-        channelMock.emit("my-channel");
+        channelMock.emit('my-channel');
 
         expect(callback).not.toHaveBeenCalled();
       });

--- a/src/__tests__/pusher-factory-mock.spec.ts
+++ b/src/__tests__/pusher-factory-mock.spec.ts
@@ -1,19 +1,19 @@
-import { PusherFactoryMock } from "../index";
+import { PusherFactoryMock } from '../index';
 
-describe("PusherFactoryMock", () => {
+describe('PusherFactoryMock', () => {
   let pusherFactoryMock: PusherFactoryMock;
 
   beforeEach(() => {
-    const pusherKey = "19ir1pkcj13";
+    const pusherKey = '19ir1pkcj13';
     pusherFactoryMock = new PusherFactoryMock(pusherKey);
   });
 
-  it("initializes pusherKey", () => {
-    expect(pusherFactoryMock.pusherKey).toEqual("19ir1pkcj13");
+  it('initializes pusherKey', () => {
+    expect(pusherFactoryMock.pusherKey).toEqual('19ir1pkcj13');
   });
 
-  describe("pusherClient", () => {
-    it("return an object", () => {
+  describe('pusherClient', () => {
+    it('return an object', () => {
       expect(pusherFactoryMock.pusherClient()).toBeDefined();
     });
   });

--- a/src/__tests__/pusher-js-mock.spec.ts
+++ b/src/__tests__/pusher-js-mock.spec.ts
@@ -1,4 +1,6 @@
 import { PusherMock } from '../index';
+import PusherChannelMock from '../pusher-channel-mock';
+import PusherPresenceChannelMock from '../pusher-presence-channel-mock';
 
 describe('PusherMock', () => {
   let pusherMock: PusherMock;
@@ -19,6 +21,11 @@ describe('PusherMock', () => {
     it('adds new channel to channels object', () => {
       pusherMock.channel('my-channel');
       expect(pusherMock.channels).toMatchObject({ 'my-channel': {} });
+    });
+
+    it('returns the correct type of channel based on channel name', () => {
+      expect(pusherMock.channel('public-channel')).toBeInstanceOf(PusherChannelMock);
+      expect(pusherMock.channel('presence-channel')).toBeInstanceOf(PusherPresenceChannelMock);
     });
 
     describe('channel is already added to channels object', () => {

--- a/src/__tests__/pusher-js-mock.spec.ts
+++ b/src/__tests__/pusher-js-mock.spec.ts
@@ -1,64 +1,64 @@
-import { PusherMock } from "../index";
+import { PusherMock } from '../index';
 
-describe("PusherMock", () => {
+describe('PusherMock', () => {
   let pusherMock: PusherMock;
 
   beforeEach(() => {
     pusherMock = new PusherMock();
   });
 
-  it("initializes channels object", () => {
+  it('initializes channels object', () => {
     expect(pusherMock.channels).toEqual({});
   });
 
-  describe("#channel", () => {
-    it("returns instance of PusherChannelMock", () => {
-      expect(pusherMock.channel("my-channel")).toBeDefined();
+  describe('#channel', () => {
+    it('returns instance of PusherChannelMock', () => {
+      expect(pusherMock.channel('my-channel')).toBeDefined();
     });
 
-    it("adds new channel to channels object", () => {
-      pusherMock.channel("my-channel");
-      expect(pusherMock.channels).toMatchObject({ "my-channel": {} });
+    it('adds new channel to channels object', () => {
+      pusherMock.channel('my-channel');
+      expect(pusherMock.channels).toMatchObject({ 'my-channel': {} });
     });
 
-    describe("channel is already added to channels object", () => {
+    describe('channel is already added to channels object', () => {
       beforeEach(() => {
-        pusherMock.channel("my-channel");
+        pusherMock.channel('my-channel');
       });
 
-      it("returns instance of PusherChannelMock", () => {
-        expect(pusherMock.channel("my-channel")).toBeDefined();
+      it('returns instance of PusherChannelMock', () => {
+        expect(pusherMock.channel('my-channel')).toBeDefined();
       });
 
-      it("adds new channel to channels object", () => {
-        expect(pusherMock.channels).toMatchObject({ "my-channel": {} });
+      it('adds new channel to channels object', () => {
+        expect(pusherMock.channels).toMatchObject({ 'my-channel': {} });
       });
     });
   });
 
-  describe("#subscribe", () => {
-    it("returns instance of PusherChannelMock", () => {
-      expect(pusherMock.channel("my-channel")).toBeDefined();
+  describe('#subscribe', () => {
+    it('returns instance of PusherChannelMock', () => {
+      expect(pusherMock.channel('my-channel')).toBeDefined();
     });
 
-    it("adds new channel to channels object", () => {
-      pusherMock.subscribe("my-channel");
-      expect(pusherMock.channels).toMatchObject({ "my-channel": {} });
+    it('adds new channel to channels object', () => {
+      pusherMock.subscribe('my-channel');
+      expect(pusherMock.channels).toMatchObject({ 'my-channel': {} });
     });
   });
 
-  describe("#unsubscribe", () => {
-    describe("channel name is inside channels object", () => {
-      it("removes channel from channels object", () => {
-        pusherMock.subscribe("my-channel");
-        pusherMock.unsubscribe("my-channel");
+  describe('#unsubscribe', () => {
+    describe('channel name is inside channels object', () => {
+      it('removes channel from channels object', () => {
+        pusherMock.subscribe('my-channel');
+        pusherMock.unsubscribe('my-channel');
         expect(pusherMock.channels).toEqual({});
       });
     });
 
-    describe("channel name is not inside channels object", () => {
-      it("removes channel from channels object", () => {
-        pusherMock.unsubscribe("my-channel");
+    describe('channel name is not inside channels object', () => {
+      it('removes channel from channels object', () => {
+        pusherMock.unsubscribe('my-channel');
         expect(pusherMock.channels).toEqual({});
       });
     });

--- a/src/__tests__/pusher-presence-channel-mock.spec.ts
+++ b/src/__tests__/pusher-presence-channel-mock.spec.ts
@@ -1,0 +1,52 @@
+import { PusherMock, PusherPresenceChannelMock } from '../';
+import { proxyPresenceChannel } from '../proxyPresenceChannel';
+
+describe('PusherPresenceChannelMock', () => {
+  let channelMock: PusherPresenceChannelMock;
+
+  beforeEach(() => {
+    channelMock = new PusherPresenceChannelMock();
+  });
+
+  it('initializes members object', () => {
+    expect(channelMock.members).toEqual({
+      count: 0,
+      members: {},
+      me: null,
+      myID: null,
+    });
+  });
+});
+
+describe('Proxied PusherPresenceChannelMock', () => {
+  let channelMock: PusherPresenceChannelMock;
+  let proxiedChannelMock: PusherPresenceChannelMock;
+  beforeEach(() => {
+    const client = new PusherMock('my-id', {});
+    channelMock = new PusherPresenceChannelMock();
+    proxiedChannelMock = proxyPresenceChannel(channelMock, client);
+  });
+
+  it('adds a new member to the channel', () => {
+    expect(channelMock.members.count).toBe(1);
+    expect(channelMock.members.get('my-id')).toEqual({ id: 'my-id', info: {} });
+  });
+
+  it('correctly proxies the channel object per client', () => {
+    expect(channelMock.myID).toBe(undefined);
+    expect(channelMock.me).toBe(undefined);
+
+    expect(proxiedChannelMock.myID).toBe('my-id');
+    expect(proxiedChannelMock.me).toEqual({ id: 'my-id', info: {} });
+  });
+
+  it('allows multiple clients to subscribe', () => {
+    const otherClient = new PusherMock('your-id', {});
+    const otherProxiedChannelMock = proxyPresenceChannel(channelMock, otherClient);
+
+    expect(proxiedChannelMock.myID).toBe('my-id');
+    expect(otherProxiedChannelMock.myID).toBe('your-id');
+
+    expect(channelMock.members.count).toBe(2);
+  });
+});

--- a/src/__tests__/pusher-presence-channel-mock.spec.ts
+++ b/src/__tests__/pusher-presence-channel-mock.spec.ts
@@ -8,6 +8,12 @@ describe('PusherPresenceChannelMock', () => {
     channelMock = new PusherPresenceChannelMock();
   });
 
+  it(' sets a name (with a default fallback)', () => {
+    expect(channelMock.name).toBe('presence-channel');
+    const namedChannelMock = new PusherPresenceChannelMock('presence-custom-name');
+    expect(namedChannelMock.name).toBe('presence-custom-name');
+  });
+
   it('initializes members object', () => {
     expect(channelMock.members).toEqual({
       count: 0,
@@ -27,12 +33,12 @@ describe('Proxied PusherPresenceChannelMock', () => {
     proxiedChannelMock = proxyPresenceChannel(channelMock, client);
   });
 
-  it('adds a new member to the channel', () => {
+  it(' adds a new member to the channel', () => {
     expect(channelMock.members.count).toBe(1);
     expect(channelMock.members.get('my-id')).toEqual({ id: 'my-id', info: {} });
   });
 
-  it('correctly proxies the channel object per client', () => {
+  it(' correctly proxies the channel object per client', () => {
     expect(channelMock.myID).toBe(undefined);
     expect(channelMock.me).toBe(undefined);
 
@@ -40,7 +46,7 @@ describe('Proxied PusherPresenceChannelMock', () => {
     expect(proxiedChannelMock.me).toEqual({ id: 'my-id', info: {} });
   });
 
-  it('allows multiple clients to subscribe', () => {
+  it(' allows multiple clients to subscribe', () => {
     const otherClient = new PusherMock('your-id', {});
     const otherProxiedChannelMock = proxyPresenceChannel(channelMock, otherClient);
 
@@ -48,5 +54,9 @@ describe('Proxied PusherPresenceChannelMock', () => {
     expect(otherProxiedChannelMock.myID).toBe('your-id');
 
     expect(channelMock.members.count).toBe(2);
+  });
+
+  it(" doesn'nt proxy class members it doesn'nt care about", () => {
+    expect(proxiedChannelMock.subscribed).toBe(true);
   });
 });

--- a/src/__tests__/pusher-presence-channel-mock.spec.ts
+++ b/src/__tests__/pusher-presence-channel-mock.spec.ts
@@ -90,4 +90,13 @@ describe('Proxied PusherPresenceChannelMock', () => {
     proxiedChannelMock.unbind('custom-event', listener);
     otherProxiedChannelMock.unbind('custom-event', otherListener);
   });
+
+  describe('#trigger', () => {
+    it(' is an alias for emit', () => {
+      let callback = jest.fn();
+      channelMock.bind('event', callback);
+      channelMock.trigger('event');
+      expect(callback).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/__tests__/pusher-presence-channel-mock.spec.ts
+++ b/src/__tests__/pusher-presence-channel-mock.spec.ts
@@ -102,37 +102,3 @@ describe('Proxied PusherPresenceChannelMock', () => {
     });
   });
 });
-
-describe('Shared instance multiple clients', () => {
-  it(' should trigger events cross-client', () => {
-    // unique clients
-    const client = new PusherMock('my-id', {});
-    const otherClient = new PusherMock('your-id', {});
-
-    // subscribe to the same channel
-    const channel = client.subscribe('presence-channel');
-    const sameChannel = otherClient.subscribe('presence-channel');
-
-    // binding to the same event
-    const listener = jest.fn();
-    channel.bind('client-event', listener);
-    const otherListener = jest.fn();
-    sameChannel.bind('client-event', otherListener);
-
-    // should receive the others events
-    channel.emit('client-event');
-    expect(listener).toHaveBeenCalledTimes(0);
-    expect(otherListener).toHaveBeenCalledTimes(1);
-
-    sameChannel.emit('client-event');
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(otherListener).toHaveBeenCalledTimes(1);
-
-    expect(channel.myID).toBe('my-id');
-    expect(sameChannel.myID).toBe('your-id');
-
-    // cleanup
-    client.unsubscribe('presence-channel');
-    otherClient.unsubscribe('presence-channel');
-  });
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import PusherChannelMock from "./pusher-channel-mock";
-import PusherFactoryMock from "./pusher-factory-mock";
-import PusherMock from "./pusher-js-mock";
+import PusherChannelMock from './pusher-channel-mock';
+import PusherFactoryMock from './pusher-factory-mock';
+import PusherMock from './pusher-js-mock';
+import PusherPresenceChannelMock from './pusher-presence-channel-mock';
 
-export { PusherMock, PusherFactoryMock, PusherChannelMock };
+export { PusherMock, PusherFactoryMock, PusherChannelMock, PusherPresenceChannelMock };

--- a/src/members.ts
+++ b/src/members.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* istanbul ignore file */
 /** COPIED DIRECTLY FROM pusher-js PACKAGE */
 export function objectApply(object: any, f: Function) {
   for (var key in object) {

--- a/src/members.ts
+++ b/src/members.ts
@@ -1,0 +1,78 @@
+/* tslint:disable */
+/** COPIED DIRECTLY FROM pusher-js PACKAGE */
+export function objectApply(object: any, f: Function) {
+  for (var key in object) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      f(object[key], key, object);
+    }
+  }
+}
+
+/** COPIED DIRECTLY FROM pusher-js PACKAGE */
+/** Represents a collection of members of a presence channel. */
+export default class Members {
+  members: any;
+  // @ts-ignore - set in this.reset()
+  count: number;
+  myID: any;
+  me: any;
+
+  constructor() {
+    this.reset();
+  }
+
+  /** Returns member's info for given id.
+   *
+   * Resulting object containts two fields - id and info.
+   *
+   * @param {Number} id
+   * @return {Object} member's info or null
+   */
+  get(id: string): any {
+    if (Object.prototype.hasOwnProperty.call(this.members, id)) {
+      return {
+        id: id,
+        info: this.members[id],
+      };
+    } else {
+      return null;
+    }
+  }
+
+  /** Calls back for each member in unspecified order.
+   *
+   * @param  {Function} callback
+   */
+  each(callback: Function) {
+    objectApply(this.members, (member: any, id: string) => {
+      callback(this.get(id));
+    });
+  }
+
+  /** Adds a new member to the collection. For internal use only. */
+  addMember(memberData: any) {
+    if (this.get(memberData.user_id) === null) {
+      this.count++;
+    }
+    this.members[memberData.user_id] = memberData.user_info;
+    return this.get(memberData.user_id);
+  }
+
+  /** Adds a member from the collection. For internal use only. */
+  removeMember(memberData: any) {
+    var member = this.get(memberData.user_id);
+    if (member) {
+      delete this.members[memberData.user_id];
+      this.count--;
+    }
+    return member;
+  }
+
+  /** Resets the collection to the initial state. For internal use only. */
+  reset() {
+    this.members = {};
+    this.count = 0;
+    this.myID = null;
+    this.me = null;
+  }
+}

--- a/src/proxyPresenceChannel.ts
+++ b/src/proxyPresenceChannel.ts
@@ -53,6 +53,8 @@ export const proxyPresenceChannel = (channel: PusherPresenceChannelMock, client:
               );
             }
           };
+        case 'IS_PROXY':
+          return true;
 
         // return other class members as they were
         default:

--- a/src/proxyPresenceChannel.ts
+++ b/src/proxyPresenceChannel.ts
@@ -1,0 +1,38 @@
+import { PusherMock, PusherPresenceChannelMock } from '.';
+
+/**
+ * Proxies the instance of channel returned so we can still reference the
+ * shared members object whilst passing our own ID & me properties
+ */
+export const proxyPresenceChannel = (channel: PusherPresenceChannelMock, client: PusherMock) => {
+  /** Add the member to the members object when  */
+  channel.members.addMember({
+    user_id: client.id,
+    user_info: client.info,
+  });
+
+  // emit channel events
+  channel.emit('pusher:subscription_succeeded', {
+    members: channel.members,
+  });
+  channel.emit('pusher:member_added', {
+    id: client.id,
+    info: client.info,
+  });
+
+  // proxy the request so me and myID remain unique to the client in question
+  const handler = {
+    get(target: PusherPresenceChannelMock, name: keyof PusherPresenceChannelMock) {
+      switch (name) {
+        case 'me':
+          return target.members.get(client.id);
+        case 'myID':
+          return client.id;
+        default:
+          return target[name];
+      }
+    },
+  };
+
+  return new Proxy(channel, handler);
+};

--- a/src/pusher-channel-mock.ts
+++ b/src/pusher-channel-mock.ts
@@ -5,10 +5,13 @@ interface ICallbacks {
 
 /** Class representing a fake Pusher channel. */
 class PusherChannelMock {
+  public name: string;
   public callbacks: ICallbacks;
+  public subscribed: boolean = true;
 
   /** Initialize PusherChannelMock with callbacks object. */
-  constructor() {
+  constructor(name: string = 'public-channel') {
+    this.name = name;
     this.callbacks = {};
   }
 
@@ -28,9 +31,7 @@ class PusherChannelMock {
    * @param {Function} callback - callback to be called on event.
    */
   public unbind(name: string, callback: () => void) {
-    this.callbacks[name] = (this.callbacks[name] || []).filter(
-      cb => cb !== callback
-    );
+    this.callbacks[name] = (this.callbacks[name] || []).filter(cb => cb !== callback);
   }
 
   /**

--- a/src/pusher-factory-mock.ts
+++ b/src/pusher-factory-mock.ts
@@ -1,4 +1,4 @@
-import PusherMock from "./pusher-js-mock";
+import PusherMock from './pusher-js-mock';
 
 /**
  * Class represents fake PusherFactory.
@@ -26,9 +26,9 @@ class PusherFactoryMock {
    * pusherClientInstance
    * @param {String} pusherKey - Pusher app key
    */
-  constructor(pusherKey: string) {
+  constructor(pusherKey: string, ...args: any[]) {
     this.pusherKey = pusherKey;
-    this.pusherClientInstance = new PusherMock();
+    this.pusherClientInstance = new PusherMock(...args);
   }
 
   /**

--- a/src/pusher-presence-channel-mock.ts
+++ b/src/pusher-presence-channel-mock.ts
@@ -1,0 +1,26 @@
+import { Member } from 'pusher-js';
+import Members from './members';
+import PusherChannelMock from './pusher-channel-mock';
+
+export interface IMember {
+  id: string;
+  info: Record<string, any>;
+}
+
+/** Basic augmentation of the PusherChannel class. */
+class PusherPresenceChannelMock extends PusherChannelMock {
+  public members: Members;
+  public me: Member<Record<string, any>> | undefined;
+  public myID: string | undefined;
+
+  /**
+   * Initialise members object when created.
+   * `pusher-js` provides all the functionality we need.
+   */
+  constructor(name: string = 'presence-channel') {
+    super(name);
+    this.members = new Members();
+  }
+}
+
+export default PusherPresenceChannelMock;

--- a/src/pusher-presence-channel-mock.ts
+++ b/src/pusher-presence-channel-mock.ts
@@ -13,6 +13,9 @@ class PusherPresenceChannelMock extends PusherChannelMock {
   public me: Member<Record<string, any>> | undefined;
   public myID: string | undefined;
 
+  /** Alias to match actual API for client events */
+  public trigger = this.emit;
+
   /**
    * Initialise members object when created.
    * `pusher-js` provides all the functionality we need.

--- a/src/pusher-presence-channel-mock.ts
+++ b/src/pusher-presence-channel-mock.ts
@@ -15,6 +15,7 @@ class PusherPresenceChannelMock extends PusherChannelMock {
 
   /** Alias to match actual API for client events */
   public trigger = this.emit;
+  public IS_PROXY?: boolean;
 
   /**
    * Initialise members object when created.

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,6 +878,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/pusher-js@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/pusher-js/-/pusher-js-4.2.2.tgz#129fae1854255c5883e874137cd045c48d0a422a"
+  integrity sha512-LP9isBRAFlNzQohQtySJxJjzmy4zQCcv5xGZD2G3rsDnTWfpEkFKyLw3x9711pFAXwwUl9ZivxKkcnFr8umSAQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
Hey @nikolalsvk, we have been mocking pusher extensively in a project here (for use in and outside of tests). We basically have a 'dev-tools' environment that sandboxes pusher inside one app. That came with its own set of challenges! Even more, we wanted to mock presence channels.

Anyway, we can get pretty close to the exact functionality of Pusher using ES6 Proxies and Classes. That's what this pull request allows.

Opening this now so we can chat about any changes you want, I'm still working on getting 100% coverage. 

Probably worth noting I copied the `Members` class directly from pusher and that's untested in this pull request (as it's tested in `pusher-js`). I'm going to ignore this coverage collection.

Let me know your thoughts!