### PR TITLE
Add unbind_all() method

### DIFF
--- a/src/__tests__/pusher-channel-mock.spec.ts
+++ b/src/__tests__/pusher-channel-mock.spec.ts
@@ -21,6 +21,23 @@ describe("PusherChannelMock", () => {
     });
   });
 
+  describe("#unbind_all", () => {
+    it("clears callbacks from all the events", () => {
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+      channelMock.bind("first-channel", firstCallback);
+      channelMock.bind("second-channel", secondCallback);
+
+      channelMock.unbind_all();
+      channelMock.emit("first-channel");
+      channelMock.emit("second-channel");
+
+      expect(firstCallback).not.toHaveBeenCalled();
+      expect(secondCallback).not.toHaveBeenCalled();
+      expect(channelMock.callbacks).toEqual({});
+    });
+  });
+
   describe("#unbind", () => {
     describe("with callbacks defined for the event", () => {
       it("removes name: callback from callbacks object", () => {

--- a/src/__tests__/pusher-channel-mock.spec.ts
+++ b/src/__tests__/pusher-channel-mock.spec.ts
@@ -22,7 +22,7 @@ describe("PusherChannelMock", () => {
   });
 
   describe("#unbind_all", () => {
-    it("clears callbacks from all the events", () => {
+    it("clears events from all the callbacks", () => {
       const firstCallback = jest.fn();
       const secondCallback = jest.fn();
       channelMock.bind("first-channel", firstCallback);

--- a/src/pusher-channel-mock.ts
+++ b/src/pusher-channel-mock.ts
@@ -35,6 +35,13 @@ class PusherChannelMock {
       cb => cb !== callback
     );
   }
+  
+  /**
+   * Unbind callbacks from all the events.
+   */
+  public unbind_all() {
+    this.callbacks = {};
+  }
 
   /**
    * Emit event with data.

--- a/src/pusher-channel-mock.ts
+++ b/src/pusher-channel-mock.ts
@@ -35,7 +35,7 @@ class PusherChannelMock {
       cb => cb !== callback
     );
   }
-  
+
   /**
    * Unbind callbacks from all the events.
    */


### PR DESCRIPTION
This method is used to unsubscribe from all the events. Original PusherChannel extends from `EventDispatcher`: https://github.com/pusher/pusher-js/blob/a55efb22433c3c303e348cdda4d763dc55cc2771/src/core/channels/channel.ts#L20
Method `unbind_all` is located in the `EventDispatcher`: https://github.com/pusher/pusher-js/blob/a55efb22433c3c303e348cdda4d763dc55cc2771/src/core/events/dispatcher.ts#L50

Would you like me to add unit tests for it?