### PR TITLE
Add allChannels method

### DIFF
--- a/src/__tests__/pusher-js-mock.spec.ts
+++ b/src/__tests__/pusher-js-mock.spec.ts
@@ -53,6 +53,21 @@ describe("PusherMock", () => {
     });
   });
 
+  describe("#allChannels", () => {
+    beforeEach(() => {
+      pusherMock.channel("public-channel");
+      pusherMock.channel("presence-channel");
+    });
+
+    it("returns an array of channel mock instances", () => {
+      const allChannels = pusherMock.allChannels();
+
+      expect(allChannels).toHaveLength(2);
+      expect(allChannels[0]).toBeInstanceOf(PusherChannelMock);
+      expect(allChannels[1]).toBeInstanceOf(PusherPresenceChannelMock);
+    });
+  });
+
   describe("#connection", () => {
     it("returns instance of connection", () => {
       expect(pusherMock.connection).toBeDefined();

--- a/src/pusher-js-mock.ts
+++ b/src/pusher-js-mock.ts
@@ -119,6 +119,13 @@ class PusherMock {
       this.channel(channelName).unbind(name, callback);
     });
   }
+
+  /**
+   * Returns a list of all channels
+   */
+  public allChannels() {
+    return Object.values(this.channels);
+  }
 }
 
 export default PusherMock;


### PR DESCRIPTION
This PR adds support for the `allChannels` method that returns an array of all subscribed channels.

The Pusher.js docs mention this method in ["Accessing Channels"](https://github.com/pusher/pusher-js/tree/c8074fe86eab49d4ac18e4b3878423c8e75c3f3d#accessing-channels).