### PR TITLE
Return mock channel instance from a few methods

### DIFF
--- a/src/__tests__/pusher-channel-mock.spec.ts
+++ b/src/__tests__/pusher-channel-mock.spec.ts
@@ -19,6 +19,10 @@ describe("PusherChannelMock", () => {
       expect(channelMock.callbacks).toMatchObject({ "my-channel": [callback] });
       expect(channelMock.callbacks["my-channel"]).toEqual([callback]);
     });
+
+    it("returns the channel mock instance", () => {
+      expect(channelMock.bind("my-channel", jest.fn())).toEqual(channelMock);
+    });
   });
 
   describe("#unbind_all", () => {
@@ -35,6 +39,10 @@ describe("PusherChannelMock", () => {
       expect(firstCallback).not.toHaveBeenCalled();
       expect(secondCallback).not.toHaveBeenCalled();
       expect(channelMock.callbacks).toEqual({});
+    });
+
+    it("returns the channel mock instance", () => {
+      expect(channelMock.unbind_all()).toEqual(channelMock);
     });
   });
 
@@ -60,6 +68,10 @@ describe("PusherChannelMock", () => {
           "my-channel": []
         });
       });
+    });
+
+    it("returns the channel mock instance", () => {
+      expect(channelMock.unbind("my-channel", jest.fn())).toEqual(channelMock);
     });
   });
 
@@ -93,6 +105,10 @@ describe("PusherChannelMock", () => {
 
         expect(callback).not.toHaveBeenCalled();
       });
+    });
+
+    it("returns the channel mock instance", () => {
+      expect(channelMock.emit("my-channel")).toEqual(channelMock);
     });
   });
 

--- a/src/pusher-channel-mock.ts
+++ b/src/pusher-channel-mock.ts
@@ -20,9 +20,11 @@ class PusherChannelMock {
    * @param {String} name - name of the event.
    * @param {Function} callback - callback to be called on event.
    */
-  public bind(name: string, callback: () => void) {
+  public bind(name: string, callback: () => void): this {
     this.callbacks[name] = this.callbacks[name] || [];
     this.callbacks[name].push(callback);
+
+    return this;
   }
 
   /**
@@ -30,17 +32,21 @@ class PusherChannelMock {
    * @param {String} name - name of the event.
    * @param {Function} callback - callback to be called on event.
    */
-  public unbind(name: string, callback: () => void) {
+  public unbind(name: string, callback: () => void): this {
     this.callbacks[name] = (this.callbacks[name] || []).filter(
       cb => cb !== callback
     );
+
+    return this;
   }
 
   /**
    * Unbind callbacks from all the events.
    */
-  public unbind_all() {
+  public unbind_all(): this {
     this.callbacks = {};
+
+    return this;
   }
 
   /**
@@ -48,12 +54,14 @@ class PusherChannelMock {
    * @param {String} name - name of the event.
    * @param {*} data - data you want to pass in to callback function that gets called.
    */
-  public emit(name: string, data?: any) {
+  public emit(name: string, data?: any): this {
     const callbacks = this.callbacks[name];
 
     if (callbacks) {
       callbacks.forEach((cb: (data?: any) => void) => cb(data));
     }
+
+    return this;
   }
 
   /**


### PR DESCRIPTION
Pusher.js allows code like this:

```ts
pusher
  .subscribe('my-channel')
  .unbind('my-event')
  .bind('my-event', myEventHandler) 
```

This PR changes the return of `bind`, `unbind`, `unbind_all`, and `emit` to return the channel mock instance so that the above is supported by this library as well.

For reference, [here's the pusher.js file](https://github.com/pusher/pusher-js/blob/master/src/core/events/dispatcher.ts) that implements these methods.